### PR TITLE
Setup watchdog

### DIFF
--- a/src/la_machine_definitions.hrl
+++ b/src/la_machine_definitions.hrl
@@ -56,3 +56,7 @@
 -define(SERVO_FREQ_HZ, 50).
 -define(SERVO_FREQ_PERIOD_US, (1000000 / ?SERVO_FREQ_HZ)).
 -define(SERVO_MAX_DUTY, ((1 bsl ?LEDC_DUTY_RESOLUTION) - 1)).
+
+% Maximum run time. If La machine runs in more than this, watchdog is triggered,
+% La machine panics and state stored in RTC Slow memory is ignored on next boot.
+-define(WATCHDOG_TIMEOUT_MS, 60000).

--- a/src/la_machine_state.erl
+++ b/src/la_machine_state.erl
@@ -92,7 +92,10 @@ save_state(State) ->
 -spec get_state() -> binary() | undefined.
 get_state() ->
     try
-        esp:rtc_slow_get_binary()
+        case esp:reset_reason() of
+            esp_rst_deepsleep -> esp:rtc_slow_get_binary();
+            _ -> undefined
+        end
     catch
         error:badarg ->
             undefined


### PR DESCRIPTION
La Machine is configured to panic if Erlang code crashs and run doesn't finish within 1 minute, and state is only loaded from RTC Slow memory if La Machine resets from deep sleep.