### PR TITLE
fix scenario not ending at 0

### DIFF
--- a/src/la_machine.erl
+++ b/src/la_machine.erl
@@ -655,6 +655,9 @@ play_scenario(MoodScenar, ScenarioIx, Config) ->
     {ok, Pid} = la_machine_player:start_link(Config),
     ok = la_machine_player:play(Pid, Scenario),
     ok = la_machine_player:stop(Pid),
+    % reset audio and servo
+    la_machine_audio:reset(),
+    la_machine_servo:reset(Config),
     ScenarioIx.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -674,6 +677,9 @@ play_scenario_with_hit(MoodScenar, ScenarioIx, Config) ->
         true -> true
     end,
     ok = la_machine_player:stop(Pid),
+    % reset audio and servo
+    la_machine_audio:reset(),
+    la_machine_servo:reset(Config),
     ScenarioIx.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
- fix scenario not ending at 0 : force reset at end of scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scenario termination to automatically ensure servos are reset when scenarios complete without an explicit shutdown command.
  * Enhanced servo state management during hit sequence control to ensure proper shutdown occurs when hits are not triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->