### PR TITLE
Allow empty scenarios for silent hits

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,5 +23,7 @@
     {proto_20241023, [
         {erl_opts, [{d, 'HARDWARE_REVISION', proto_20241023}]}
     ]},
-    {'4mb', []}
+    {'4mb', [
+        {erl_opts, [{d, 'CHOREOGRAPHIES_FILE', "choreographies-4mb.json"}]}
+    ]}
 ]}.

--- a/src/la_machine_scenarios.erl
+++ b/src/la_machine_scenarios.erl
@@ -60,4 +60,38 @@ get_test_() ->
     [
         ?_assert(is_list(get(excited, 1)))
     ].
+
+%% All known scenario types. Update this list when adding a new type.
+-define(ALL_TYPES, [
+    calling,
+    excited,
+    game_long,
+    game_medium,
+    game_short,
+    hits,
+    joy,
+    meuh,
+    poke,
+    test,
+    tired,
+    upset
+]).
+
+-ifdef(CHOREOGRAPHIES_FILE).
+-define(JSON_PATH, "src_scenarios/" ?CHOREOGRAPHIES_FILE).
+-else.
+-define(JSON_PATH, "src_scenarios/choreographies.json").
+-endif.
+
+no_entry_filtered_by_build_assets_test() ->
+    case erlang:system_info(machine) of
+        "ATOM" ->
+            ok;
+        "BEAM" ->
+            {ok, JsonBin} = file:read_file(?JSON_PATH),
+            Choreographies = json:decode(JsonBin),
+            JsonCount = map_size(Choreographies),
+            GeneratedCount = lists:sum([count(T) || T <- ?ALL_TYPES]),
+            ?assertEqual(JsonCount, GeneratedCount)
+    end.
 -endif.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure all formatted choreography commands are consistently propagated and included in generated outputs; improve name-based grouping so entries with numeric suffixes are grouped by their base type.

* **Tests**
  * Added validation test that asserts choreography source entries match expected counts across all scenario types.

* **Chores**
  * Updated build profile to reference the 4MB choreography dataset used for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->