### PR TITLE
Verify sounds partition maps sound index file with a sha1 sum

### DIFF
--- a/src/la_machine.erl
+++ b/src/la_machine.erl
@@ -117,6 +117,12 @@ run() ->
 
     la_machine_battery:init(),
     WakeupCause = esp:sleep_get_wakeup_cause(),
+    case WakeupCause of
+        undefined ->
+            ok = la_machine_sounds:verify_partition();
+        _ ->
+            ok
+    end,
 
     Config = la_machine_configuration:load(),
     SelfTestState = la_machine_configuration:self_test_state(Config),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added integrity verification for sound assets through a checksum mechanism.
  * Enhanced sound file build process to compute and validate asset checksums during partition rebuild.

* **Improvements**
  * Sound partition now includes built-in verification to ensure data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->