### PR TITLE
Change `{servo, _}` asynchronous behavior and fix servo speed

### DIFF
--- a/src/la_machine_definitions.hrl
+++ b/src/la_machine_definitions.hrl
@@ -101,8 +101,8 @@
 -define(SERVO_FREQ_HZ, 50).
 -define(SERVO_FREQ_PERIOD_US, (1000000 / ?SERVO_FREQ_HZ)).
 -define(SERVO_MAX_DUTY, ((1 bsl ?LEDC_DUTY_RESOLUTION) - 1)).
-% Time for full servo range in ms. Servo is 0.3s/60°, full 180° = 900ms.
--define(SERVO_FULL_RANGE_TIME_MS, 900).
+% Time for full servo range in ms. Full 180° takes between 1200 and 1350ms
+-define(SERVO_FULL_RANGE_TIME_MS, 1350).
 
 % Maximum run time. If La machine runs in more than this, watchdog is triggered,
 % La machine panics and state stored in RTC Slow memory is ignored on next boot.

--- a/src/la_machine_selftest.erl
+++ b/src/la_machine_selftest.erl
@@ -51,7 +51,7 @@
 -define(DUTY_COURSE, 865).
 % Expected range for the 85% target duty (where the arm just touches the
 % button but doesn't push it off).
--define(MIN_85_DUTY, 700).
+-define(MIN_85_DUTY, 660).
 -define(MAX_85_DUTY, 864).
 
 % Duty units are on 14 bits (16384)

--- a/src/la_machine_servo.erl
+++ b/src/la_machine_servo.erl
@@ -341,7 +341,7 @@ target_duty_timeout_test_() ->
                     })
                 ),
                 ?_assertMatch(
-                    {313, #state{
+                    {469, #state{
                         pre_min = 318,
                         pre_max = 887,
                         target = 887,
@@ -363,7 +363,7 @@ target_duty_timeout_test_() ->
                     })
                 ),
                 ?_assertMatch(
-                    {313, #state{
+                    {469, #state{
                         pre_min = 318,
                         pre_max = 887,
                         target = 318,

--- a/test/la_machine_servo_mock.erl
+++ b/test/la_machine_servo_mock.erl
@@ -40,6 +40,7 @@
     set_target/2,
     set_target/3,
     timeout/1,
+    stop_fade/1,
     power_off/0
 ]).
 
@@ -56,6 +57,9 @@ set_target(Target, TimeMS, State) ->
 
 timeout(State) ->
     mock:call(?MOCK_SERVER_NAME, timeout, [State]).
+
+stop_fade(State) ->
+    mock:call(?MOCK_SERVER_NAME, stop_fade, [State]).
 
 power_off() ->
     mock:call(?MOCK_SERVER_NAME, power_off, []).


### PR DESCRIPTION
`{servo, _}` used to wait when a previous servo movement wasn't finished. It will now interrupt the previous movement and move forward with the new movement. If the previous movement was a fade, and the new servo command is also a fade, the new servo command will consider the target position as the current position for fade calculation, even if the position was not reached.

Also, the 900ms speed (900ms to run 180°) seems wrong by a significant factor with the servos because they are not powered with a high enough voltage. Change this value to 1350ms. This affects the end of the sequence and any `{wait, servo}` command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Servo fades now reliably stop before new servo commands, preventing lingering fades during sequences.

* **Updates**
  * Increased servo full-range movement timing to 1350ms for more accurate 180° rotations.
  * Narrowed the 85% duty acceptance threshold for tighter servo responsiveness.

* **Tests**
  * Improved tests for fade-stop behavior and updated timing validations across multi-step servo scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->