### PR TITLE
Add factory mode, before provisionning mode

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,6 +81,7 @@ jobs:
         rebar3 as test atomvm packbeam \
             -s eunit \
             -e $PWD/_build/test/lib/la_machine/test/la_machine_audio_mock.beam \
+            -e $PWD/_build/test/lib/la_machine/test/la_machine_battery_mock.beam \
             -e $PWD/_build/test/lib/la_machine/test/la_machine_servo_mock.beam \
             -e $PWD/_build/test/lib/la_machine/test/mock.beam \
             -e $PWD/../AtomVM/build/libs/etest/src/beams/eunit.beam \

--- a/src/la_machine.erl
+++ b/src/la_machine.erl
@@ -29,6 +29,9 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-define(BATTERY_MODULE, la_machine_battery_mock).
+-else.
+-define(BATTERY_MODULE, la_machine_battery).
 -endif.
 
 % We use eunit:start/0 entry point for tests.
@@ -95,8 +98,11 @@ configure_gpios() ->
 %% `accelerometer` configures only the accelerometer GPIO
 %% `button' configures only the button GPIO (self test, provisioning)
 %% `both' configures button and accelerometer GPIO (used after calibration).
+%% `none` configures no GPIO
 %% @end
--spec enable_gpio_wakeup(accelerometer | button | both) -> ok.
+-spec enable_gpio_wakeup(accelerometer | button | both | none) -> ok.
+enable_gpio_wakeup(none) ->
+    ok;
 enable_gpio_wakeup(Pins) ->
     PinMask =
         case Pins of
@@ -135,7 +141,7 @@ run() ->
     Config = la_machine_configuration:load(),
     SelfTestState = la_machine_configuration:self_test_state(Config),
 
-    {SleepTimer, WakeupGPIO} =
+    {SleepSecs, WakeupGPIO} =
         case SelfTestState of
             uncalibrated ->
                 ButtonState = read_button(),
@@ -146,9 +152,9 @@ run() ->
                 Config1 = la_machine_configuration:set_self_test_reported(Config),
                 la_machine_configuration:save(Config1),
                 RTCState0 = la_machine_state:load_state(),
-                RTCState1 = la_machine_state:set_wakeup_state(provisioning, RTCState0),
+                RTCState1 = la_machine_state:set_wakeup_state(factory, RTCState0),
                 la_machine_state:save_state(RTCState1),
-                {infinity, button};
+                {?FACTORY_POLL_TIMEOUT_BUTTON_OFF, button};
             calibrated ->
                 ButtonState = read_button(),
                 BatteryCharging = la_machine_battery:is_charging(),
@@ -160,10 +166,10 @@ run() ->
         end,
     enable_gpio_wakeup(WakeupGPIO),
     unconfigure_watchdog(WatchdogUser),
-    case SleepTimer of
+    case SleepSecs of
         infinity ->
             esp:deep_sleep();
-        SleepSecs when is_integer(SleepSecs) ->
+        _ when is_integer(SleepSecs) ->
             esp:deep_sleep(SleepSecs * 1000)
     end.
 
@@ -238,14 +244,35 @@ compute_action(WakeupCause, ButtonState, AccelerometerState, BatteryLevel, State
     la_machine_state:wakeup_state(),
     boolean()
 ) ->
-    {non_neg_integer() | infinity, accelerometer | button | both}.
+    {non_neg_integer() | infinity, accelerometer | button | both | none}.
+% factory state: poll for charger or full battery to transition to provisioning
+run_configured(_Config, _WakeupCause, ButtonState, State0, factory, false) ->
+    case ?BATTERY_MODULE:get_level() of
+        {ok, Level} when Level >= 100 ->
+            State1 = la_machine_state:set_wakeup_state(provisioning, State0),
+            la_machine_state:save_state(State1),
+            {?SERVO_CHARGING_TIMEOUT, button};
+        _ ->
+            % Ensure factory state is saved for next boot
+            la_machine_state:save_state(State0),
+            case ButtonState of
+                off ->
+                    {?FACTORY_POLL_TIMEOUT_BUTTON_OFF, button};
+                on ->
+                    {?FACTORY_POLL_TIMEOUT_BUTTON_ON, none}
+            end
+    end;
+run_configured(_Config, _WakeupCause, _ButtonState, State0, factory, true) ->
+    State1 = la_machine_state:set_wakeup_state(provisioning, State0),
+    la_machine_state:save_state(State1),
+    {?SERVO_CHARGING_TIMEOUT, button};
 % provisioning state: wait for the button, even if La Machine is being charged
 run_configured(_Config, _WakeupCause, off, _State0, provisioning, false) ->
     {infinity, button};
 run_configured(_Config, _WakeupCause, off, _State0, provisioning, true) ->
     wait_while_charging(40000),
     {?SERVO_CHARGING_TIMEOUT, button};
-run_configured(Config, sleep_wakeup_gpio, on, State0, provisioning, _Charging) ->
+run_configured(Config, _WakeupCause, on, State0, provisioning, _Charging) ->
     % First run.
     play_welcome(Config),
     State1 = la_machine_state:set_wakeup_state(normal, State0),
@@ -319,12 +346,13 @@ run_configured(Config, _WakeupCause, ButtonState, State0, travel, false) ->
                         off ->
                             {infinity, both}
                     end
-            end                    
+            end
     end;
 run_configured(Config, WakeupCause, ButtonState, State0, normal, Charging) ->
     AccelerometerState = la_machine_lis3dh:setup(ButtonState =:= off),
-    {ok, BatteryLevel} = la_machine_battery:get_level(),
+    {ok, BatteryLevel} = ?BATTERY_MODULE:get_level(),
 
+    %% erlfmt:ignore-begin
     State1 =
         case compute_action(WakeupCause, ButtonState, AccelerometerState, BatteryLevel, State0) of
             ?DEBUG_PLAY_SCENARIO_CASE(Config, State0)
@@ -371,6 +399,7 @@ run_configured(Config, WakeupCause, ButtonState, State0, normal, Charging) ->
                 la_machine_servo:reset(Config),
                 State0
         end,
+    %% erlfmt:ignore-end
     la_machine_state:save_state(State1),
     Timer = case Charging of
         true ->
@@ -994,4 +1023,52 @@ compute_sleep_timer_test_() ->
             ]
         }
     ].
+
+run_configured_factory_test_() ->
+    {
+        setup,
+        fun() -> la_machine_battery_mock:new() end,
+        fun(BatteryMock) -> la_machine_battery_mock:delete(BatteryMock) end,
+        fun(BatteryMock) ->
+            State = la_machine_state:new(),
+            Config = undefined,
+            [
+                {"battery full transitions to provisioning",
+                    ?_test(begin
+                        la_machine_battery_mock:expect(BatteryMock, get_level, {ok, 100}),
+                        {Timeout, Wakeup} = run_configured(
+                            Config, undefined, off, State, factory, false
+                        ),
+                        ?assertEqual(?SERVO_CHARGING_TIMEOUT, Timeout),
+                        ?assertEqual(button, Wakeup)
+                    end)},
+                {"charging flag true transitions to provisioning",
+                    ?_test(begin
+                        {Timeout, Wakeup} = run_configured(
+                            Config, undefined, off, State, factory, true
+                        ),
+                        ?assertEqual(?SERVO_CHARGING_TIMEOUT, Timeout),
+                        ?assertEqual(button, Wakeup)
+                    end)},
+                {"button off, not charging returns factory poll timeout button off",
+                    ?_test(begin
+                        la_machine_battery_mock:expect(BatteryMock, get_level, {error, no_adc}),
+                        {Timeout, Wakeup} = run_configured(
+                            Config, undefined, off, State, factory, false
+                        ),
+                        ?assertEqual(?FACTORY_POLL_TIMEOUT_BUTTON_OFF, Timeout),
+                        ?assertEqual(button, Wakeup)
+                    end)},
+                {"button on, not charging returns factory poll timeout button on",
+                    ?_test(begin
+                        la_machine_battery_mock:expect(BatteryMock, get_level, {error, no_adc}),
+                        {Timeout, Wakeup} = run_configured(
+                            Config, undefined, on, State, factory, false
+                        ),
+                        ?assertEqual(?FACTORY_POLL_TIMEOUT_BUTTON_ON, Timeout),
+                        ?assertEqual(none, Wakeup)
+                    end)}
+            ]
+        end
+    }.
 -endif.

--- a/src/la_machine_definitions.hrl
+++ b/src/la_machine_definitions.hrl
@@ -122,6 +122,10 @@
 -define(SERVO_CHARGING_POSITION, 70).
 % When charging, wakeup constantly
 -define(SERVO_CHARGING_TIMEOUT, 0).
+% In factory mode, poll every 60 seconds to detect charger insertion
+-define(FACTORY_POLL_TIMEOUT_BUTTON_OFF, 60).
+% If button is on, check every 5 seconds
+-define(FACTORY_POLL_TIMEOUT_BUTTON_ON, 5).
 
 %% Moods
 

--- a/src/la_machine_state.erl
+++ b/src/la_machine_state.erl
@@ -83,7 +83,8 @@
     normal
     | provisioning
     | charging
-    | travel.
+    | travel
+    | factory.
 
 -type mood() ::
     waiting
@@ -129,30 +130,38 @@ load_state() ->
     Now = erlang:system_time(second),
     deserialize_state(Now, get_state()).
 
+-ifdef(TEST).
+save_state(_State) -> ok.
+-else.
 save_state(State) ->
     Bin = serialize_state(State),
     ok = esp:rtc_slow_set_binary(Bin).
+-endif.
 
--spec get_state() -> binary() | undefined.
+-spec get_state() -> binary() | undefined | watchdog | error | other_reset.
 get_state() ->
     try
         case esp:reset_reason() of
             esp_rst_deepsleep -> esp:rtc_slow_get_binary();
-            _ -> undefined
+            esp_rst_int_wdt -> watchdog;
+            esp_rst_task_wdt -> watchdog;
+            esp_rst_wdt -> watchdog;
+            _ -> other_reset
         end
     catch
         error:badarg ->
-            undefined
+            error
     end.
 
--spec deserialize_state(non_neg_integer(), binary() | undefined) -> state().
+-spec deserialize_state(non_neg_integer(), binary() | undefined | watchdog | error | other_reset) ->
+    state().
 deserialize_state(
     Now,
-    <<WakeupStateInt:2, MoodInt:4, 0:2, BootTime:64, LastPlayTime:64, LastPlaySeq:32,
+    <<WakeupStateInt:3, MoodInt:4, 0:1, BootTime:64, LastPlayTime:64, LastPlaySeq:32,
         GestureCount:8, TotalGestureCount:16, BatteryLow:8, LastOn:64, ClickCount:8,
         PlayPokeIndex:8, PlayHours/binary>>
 ) when
-    WakeupStateInt =< 3 andalso MoodInt =< 8 andalso
+    WakeupStateInt =< 4 andalso MoodInt =< 8 andalso
         BootTime =< Now andalso byte_size(PlayHours) =< ?MAX_PLAY_HOURS
 ->
     %io:format("deserialize_state  : BootTime=~p Now=~p playhours_size=~p => Retrieving State\n", [BootTime, Now, byte_size(PlayHours)]),
@@ -172,9 +181,16 @@ deserialize_state(
         play_poke_index = PlayPokeIndex,
         play_hours = PlayHours
     };
-deserialize_state(Now, _) ->
+deserialize_state(Now, State) ->
+    WakeupState =
+        case State of
+            watchdog -> normal;
+            error -> normal;
+            other_reset -> factory;
+            _ -> normal
+        end,
     #state{
-        wakeup_state = normal,
+        wakeup_state = WakeupState,
         boot_time = Now,
         last_play_time = 0,
         last_play_seq = 0,
@@ -205,21 +221,23 @@ serialize_state(#state{
 }) ->
     WakeupStateInt = serialize_wakeup_state(WakeupState),
     MoodInt = serialize_mood(Mood),
-    <<WakeupStateInt:2, MoodInt:4, 0:2, BootTime:64, LastPlayTime:64, LastPlaySeq:32,
+    <<WakeupStateInt:3, MoodInt:4, 0:1, BootTime:64, LastPlayTime:64, LastPlaySeq:32,
         GestureCount:8, TotalGestureCount:16, BatteryLow:8, LastOn:64, ClickCount:8,
         PlayPokeIndex:8, PlayHours/binary>>.
 
--spec serialize_wakeup_state(wakeup_state()) -> 0..3.
+-spec serialize_wakeup_state(wakeup_state()) -> 0..4.
 serialize_wakeup_state(normal) -> 0;
 serialize_wakeup_state(provisioning) -> 1;
 serialize_wakeup_state(charging) -> 2;
-serialize_wakeup_state(travel) -> 3.
+serialize_wakeup_state(travel) -> 3;
+serialize_wakeup_state(factory) -> 4.
 
--spec deserialize_wakeup_state(0..3) -> wakeup_state().
+-spec deserialize_wakeup_state(0..4) -> wakeup_state().
 deserialize_wakeup_state(0) -> normal;
 deserialize_wakeup_state(1) -> provisioning;
 deserialize_wakeup_state(2) -> charging;
-deserialize_wakeup_state(3) -> travel.
+deserialize_wakeup_state(3) -> travel;
+deserialize_wakeup_state(4) -> factory.
 
 -spec serialize_mood(mood()) -> 0..8.
 serialize_mood(waiting) -> 0;
@@ -404,7 +422,7 @@ deserialize_state_test_() ->
                 play_hours = <<>>
             },
             deserialize_state(
-                42, <<1:2, 4:4, 0:2, 1:64, 2:64, 3:32, 5:8, 6:16, 7:8, 8:64, 9:8, 11:8>>
+                42, <<1:3, 4:4, 0:1, 1:64, 2:64, 3:32, 5:8, 6:16, 7:8, 8:64, 9:8, 11:8>>
             )
         ),
         ?_assertEqual(
@@ -422,7 +440,7 @@ deserialize_state_test_() ->
                 play_poke_index = 4,
                 play_hours = <<5>>
             },
-            deserialize_state(42, <<1:2, 0:6, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8, 5>>)
+            deserialize_state(42, <<1:3, 0:5, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8, 5>>)
         ),
         ?_assertEqual(
             #state{
@@ -440,7 +458,7 @@ deserialize_state_test_() ->
                 play_hours = <<5, 6>>
             },
             deserialize_state(
-                42, <<1:2, 0:6, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8, 5, 6>>
+                42, <<1:3, 0:5, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8, 5, 6>>
             )
         ),
         ?_assertEqual(
@@ -459,7 +477,7 @@ deserialize_state_test_() ->
                 play_hours = <<5, 6>>
             },
             deserialize_state(
-                42, <<1:2, 0:6, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8, 5, 6>>
+                42, <<1:3, 0:5, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8, 5, 6>>
             )
         ),
         % BootTime > Now should fall back to default
@@ -485,7 +503,7 @@ deserialize_state_test_() ->
                 play_hours = <<>>
             },
             deserialize_state(
-                42, <<1:2, 9:4, 0:2, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8>>
+                42, <<1:3, 9:4, 0:1, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8>>
             )
         ),
         % travel wakeup state
@@ -505,7 +523,27 @@ deserialize_state_test_() ->
                 play_hours = <<>>
             },
             deserialize_state(
-                42, <<3:2, 0:4, 0:2, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8>>
+                42, <<3:3, 0:4, 0:1, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8>>
+            )
+        ),
+        % factory wakeup state
+        ?_assertEqual(
+            #state{
+                wakeup_state = factory,
+                boot_time = 1,
+                last_play_time = 2,
+                last_play_seq = 3,
+                mood = waiting,
+                gesture_count = 0,
+                total_gesture_count = 0,
+                battery_low = 0,
+                last_on = 0,
+                click_count = 0,
+                play_poke_index = 4,
+                play_hours = <<>>
+            },
+            deserialize_state(
+                42, <<4:3, 0:4, 0:1, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8>>
             )
         )
     ].
@@ -533,7 +571,7 @@ serialize_state_test_() ->
             )
         ),
         ?_assertEqual(
-            <<1:2, 4:4, 0:2, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8>>,
+            <<1:3, 4:4, 0:1, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8>>,
             serialize_state(
                 #state{
                     wakeup_state = provisioning,
@@ -547,7 +585,7 @@ serialize_state_test_() ->
             )
         ),
         ?_assertEqual(
-            <<1:2, 5:4, 0:2, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8, 5>>,
+            <<1:3, 5:4, 0:1, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8, 5>>,
             serialize_state(
                 #state{
                     wakeup_state = provisioning,
@@ -561,7 +599,7 @@ serialize_state_test_() ->
             )
         ),
         ?_assertEqual(
-            <<1:2, 8:4, 0:2, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8, 5>>,
+            <<1:3, 8:4, 0:1, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8, 5>>,
             serialize_state(
                 #state{
                     wakeup_state = provisioning,
@@ -575,7 +613,7 @@ serialize_state_test_() ->
             )
         ),
         ?_assertEqual(
-            <<1:2, 6:4, 0:2, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8, 5, 6>>,
+            <<1:3, 6:4, 0:1, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8, 5, 6>>,
             serialize_state(
                 #state{
                     wakeup_state = provisioning,
@@ -589,10 +627,24 @@ serialize_state_test_() ->
             )
         ),
         ?_assertEqual(
-            <<3:2, 0:4, 0:2, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8>>,
+            <<3:3, 0:4, 0:1, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8>>,
             serialize_state(
                 #state{
                     wakeup_state = travel,
+                    mood = waiting,
+                    boot_time = 1,
+                    last_play_time = 2,
+                    last_play_seq = 3,
+                    play_poke_index = 4,
+                    play_hours = <<>>
+                }
+            )
+        ),
+        ?_assertEqual(
+            <<4:3, 0:4, 0:1, 1:64, 2:64, 3:32, 0:8, 0:16, 0:8, 0:64, 0:8, 4:8>>,
+            serialize_state(
+                #state{
+                    wakeup_state = factory,
                     mood = waiting,
                     boot_time = 1,
                     last_play_time = 2,
@@ -623,7 +675,7 @@ serialize_wakeup_state_test() ->
             Serialized = serialize_wakeup_state(WakeupState),
             ?assertEqual(Serialized, N)
         end,
-        lists:seq(0, 3)
+        lists:seq(0, 4)
     ).
 
 -endif.

--- a/test/la_machine_battery_mock.erl
+++ b/test/la_machine_battery_mock.erl
@@ -1,0 +1,57 @@
+%
+% This file is part of La Machine
+%
+% Copyright 2024 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0
+%
+
+%%-----------------------------------------------------------------------------
+%% @doc La Machine battery mock interface
+%% @end
+%%-----------------------------------------------------------------------------
+
+-module(la_machine_battery_mock).
+
+-include_lib("eunit/include/eunit.hrl").
+
+% mock interface
+-export([
+    new/0,
+    expect/3,
+    assert_called/2,
+    delete/1
+]).
+
+-export([
+    get_level/0
+]).
+
+-define(MOCK_SERVER_NAME, ?MODULE).
+
+get_level() ->
+    mock:call(?MOCK_SERVER_NAME, get_level, []).
+
+new() ->
+    mock:new(?MOCK_SERVER_NAME).
+
+delete(MockServer) ->
+    mock:delete(MockServer).
+
+expect(MockServer, Function, Callback) ->
+    mock:expect(MockServer, Function, Callback).
+
+assert_called(MockServer, Function) ->
+    mock:assert_called(MockServer, Function).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a factory wakeup mode for initial device setup and configuration.
  * Battery-level polling in factory mode to detect full charge and transition to provisioning.
  * Distinct factory polling intervals when the button is on (short) vs off (long).
  * Option to disable GPIO wakeup so devices can ignore GPIO wake events.

* **Bug Fixes**
  * Improved wakeup and state-transition handling across factory/provisioning based on charge and button state.

* **Tests**
  * Added a battery-level test mock and expanded unit test coverage for factory behavior; CI test packaging updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->