### PR TITLE
Pull stat2 gpio up

### DIFF
--- a/src/la_machine_battery.erl
+++ b/src/la_machine_battery.erl
@@ -43,6 +43,7 @@
 init() ->
     ok = gpio:init(?BATTERY_STAT2_GPIO),
     ok = gpio:set_pin_mode(?BATTERY_STAT2_GPIO, input),
+    ok = gpio:set_pin_pull(?BATTERY_STAT2_GPIO, up),
     ok.
 
 %% @doc Determine if the battery is currently charging.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configured battery status GPIO pin pull-up setting to ensure proper signal handling during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->